### PR TITLE
Two bug fixes + ability to retrieve Amazon instance IDs

### DIFF
--- a/lib/engineyard-metadata/amazon_ec2_api.rb
+++ b/lib/engineyard-metadata/amazon_ec2_api.rb
@@ -1,4 +1,4 @@
-require 'eat'
+require 'open-uri'
 
 module EY
   class Metadata
@@ -6,12 +6,12 @@ module EY
     class AmazonEc2Api
       # The present instance's Amazon Ec2 instance id.
       def present_instance_id
-        @present_instance_id ||= eat 'http://169.254.169.254/latest/meta-data/instance-id'
+        @present_instance_id ||= open('http://169.254.169.254/latest/meta-data/instance-id').read
       end
 
       # The present instance's Amazon Ec2 security group.
       def present_security_group
-        @present_security_group ||= eat 'http://169.254.169.254/latest/meta-data/security-groups'
+        @present_security_group ||= open('http://169.254.169.254/latest/meta-data/security-groups').read
       end
     end
   end

--- a/lib/engineyard-metadata/chef_dna.rb
+++ b/lib/engineyard-metadata/chef_dna.rb
@@ -69,63 +69,63 @@ module EY
         dna['engineyard']['environment']['ssh_password']
       end
   
-      # The public hostnames of all the app servers.
+      # An identifying attribute of each app server. Defaults to public_hostname.
       #
       # If you're on a solo app, it counts the solo as an app server.
-      def app_servers
-        dna['engineyard']['environment']['instances'].select { |i| %w{ app_master app solo }.include? i['role'] }.map { |i| i['public_hostname'] }.sort
+      def app_servers(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
+        dna['engineyard']['environment']['instances'].select { |i| %w{ app_master app solo }.include? i['role'] }.map { |i| i[normalize_identifier(identifier)] }.sort
       end
-    
-      # The public hostnames of all the app slaves.
-      def app_slaves
-        dna['engineyard']['environment']['instances'].select { |i| %w{ app }.include? i['role'] }.map { |i| i['public_hostname'] }.sort
+   
+      # An identifying attribute of each app slave. Defaults to public_hostname. 
+      def app_slaves(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
+        dna['engineyard']['environment']['instances'].select { |i| %w{ app }.include? i['role'] }.map { |i| i[normalize_identifier(identifier)] }.sort
       end
-  
-      # The public hostnames of all the db servers.
+
+      # An identifying attribute of each DB server. Defaults to public_hostname.
       #
       # If you're on a solo app, it counts the solo as a db server.
-      def db_servers
-        dna['engineyard']['environment']['instances'].select { |i| %w{ db_master db_slave solo }.include? i['role'] }.map { |i| i['public_hostname'] }.sort
+      def db_servers(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
+        dna['engineyard']['environment']['instances'].select { |i| %w{ db_master db_slave solo }.include? i['role'] }.map { |i| i[normalize_identifier(identifier)] }.sort
       end
   
-      # The public hostnames of all the db slaves.
-      def db_slaves
-        dna['engineyard']['environment']['instances'].select { |i| %w{ db_slave }.include? i['role'] }.map { |i| i['public_hostname'] }.sort
+      # An identifying attribute of each DB slave. Defaults to public_hostname.
+      def db_slaves(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
+        dna['engineyard']['environment']['instances'].select { |i| %w{ db_slave }.include? i['role'] }.map { |i| i[normalize_identifier(identifier)] }.sort
       end
   
-      # The public hostnames of all the utility servers.
+      # An identifying attribute of each utility server. Defaults to public_hostname.
       #
       # If you're on a solo app, it counts the solo as a utility.
-      def utilities
-        dna['engineyard']['environment']['instances'].select { |i| %w{ util solo }.include? i['role'] }.map { |i| i['public_hostname'] }.sort
+      def utilities(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
+        dna['engineyard']['environment']['instances'].select { |i| %w{ util solo }.include? i['role'] }.map { |i| i[normalize_identifier(identifier)] }.sort
       end
   
-      # The public hostname of the app_master.
+      # An identifying attribute of the app_master. Defaults to public_hostname.
       #
       # If you're on a solo app, it counts the solo as the app_master.
-      def app_master
+      def app_master(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
         if x = dna['engineyard']['environment']['instances'].detect { |i| i['role'] == 'app_master' }
-          x['public_hostname']
+          x[normalize_identifier(identifier)]
         else
-          solo
+          solo(identifier)
         end
       end
   
-      # The public hostname of the db_master.
+      # An identifying attribute of the db_master. Defaults to public_hostname.
       #
-      # If you're on a solo app, it counts the solo as the app_master.
-      def db_master
+      # If you're on a solo app, it counts the solo as the db_master.
+      def db_master(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
         if x = dna['engineyard']['environment']['instances'].detect { |i| i['role'] == 'db_master' }
-          x['public_hostname']
+          x[normalize_identifier(identifier)]
         else
-          solo
+          solo(identifier)
         end
       end
     
-      # The public hostname of the solo.
-      def solo
+      # An identifying attribute of the solo. Defaults to public_hostname.
+      def solo(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
         if x = dna['engineyard']['environment']['instances'].detect { |i| i['role'] == 'solo' }
-          x['public_hostname']
+          x[normalize_identifier(identifier)]
         end
       end
 
@@ -147,6 +147,10 @@ module EY
       # The stack in use, like nginx_passenger.
       def stack_name
         dna['engineyard']['environment']['stack_name']
+      end
+
+      def normalize_identifier(identifier)
+        (identifier == 'amazon_id') ? 'id' : identifier
       end
     end
   end

--- a/lib/engineyard-metadata/chef_dna.rb
+++ b/lib/engineyard-metadata/chef_dna.rb
@@ -5,7 +5,6 @@ require 'active_support/version'
 }.each do |active_support_3_requirement|
   require active_support_3_requirement
 end if ActiveSupport::VERSION::MAJOR == 3
-require 'eat'
 
 module EY
   class Metadata
@@ -16,7 +15,7 @@ module EY
       include SshAliasHelper
 
       def dna # :nodoc:
-        @dna ||= ActiveSupport::JSON.decode eat(PATH)
+        @dna ||= ActiveSupport::JSON.decode File.read(PATH)
       end
       
       def application # :nodoc:

--- a/lib/engineyard-metadata/engine_yard_cloud_api.rb
+++ b/lib/engineyard-metadata/engine_yard_cloud_api.rb
@@ -46,63 +46,63 @@ module EY
         db_master
       end
 
-      # The public hostname of the db_master.
+      # An identifying attribute of the db_master. Defaults to public_hostname.
       #
-      # If you're on a solo app, it counts the solo as the app_master.
-      def db_master
+      # If you're on a solo app, it counts the solo as the db_master.
+      def db_master(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
         if x = environment['instances'].detect { |i| i['role'] == 'db_master' }
-          x['public_hostname']
+          x[identifier]
         else
-          solo
+          solo(identifier)
         end
       end
       
-      # The public hostnames of all the app servers.
+      # An identifying attribute of each app server. Defaults to public_hostname.
       #
       # If you're on a solo app, it counts the solo as an app server.
-      def app_servers
-        environment['instances'].select { |i| %w{ app_master app solo }.include? i['role'] }.map { |i| i['public_hostname'] }.sort
+      def app_servers(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
+        environment['instances'].select { |i| %w{ app_master app solo }.include? i['role'] }.map { |i| i[identifier] }.sort
       end
       
-      # The public hostnames of all the db servers.
+      # An identifying attribute of each DB server. Defaults to public_hostname.
       #
       # If you're on a solo app, it counts the solo as a db server.
-      def db_servers
-        environment['instances'].select { |i| %w{ db_master db_slave solo }.include? i['role'] }.map { |i| i['public_hostname'] }.sort
+      def db_servers(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
+        environment['instances'].select { |i| %w{ db_master db_slave solo }.include? i['role'] }.map { |i| i[identifier] }.sort
       end
       
-      # The public hostnames of all the utility servers.
+      # An identifying attribute of each utility server. Defaults to public_hostname.
       #
       # If you're on a solo app, it counts the solo as a utility.
-      def utilities
-        environment['instances'].select { |i| %w{ util solo }.include? i['role'] }.map { |i| i['public_hostname'] }.sort
+      def utilities(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
+        environment['instances'].select { |i| %w{ util solo }.include? i['role'] }.map { |i| i[identifier] }.sort
       end
       
-      # The public hostnames of all the app slaves.
-      def app_slaves
-        environment['instances'].select { |i| %w{ app }.include? i['role'] }.map { |i| i['public_hostname'] }.sort
+      # An identifying attribute of each app slave. Defaults to public_hostname. 
+      def app_slaves(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
+        environment['instances'].select { |i| %w{ app }.include? i['role'] }.map { |i| i[identifier] }.sort
       end
   
-      # The public hostnames of all the db slaves.
-      def db_slaves
-        environment['instances'].select { |i| %w{ db_slave }.include? i['role'] }.map { |i| i['public_hostname'] }.sort
+      # An identifying attribute of each DB slave. Defaults to public_hostname.
+      def db_slaves(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
+        environment['instances'].select { |i| %w{ db_slave }.include? i['role'] }.map { |i| i[identifier] }.sort
       end
       
-      # The public hostname of the app_master.
+      # An identifying attribute of the app_master. Defaults to public_hostname.
       #
       # If you're on a solo app, it counts the solo as the app_master.
-      def app_master
+      def app_master(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
         if x = environment['instances'].detect { |i| i['role'] == 'app_master' }
-          x['public_hostname']
+          x[identifier]
         else
-          solo
+          solo(identifier)
         end
       end
 
-      # The public hostname of the solo.
-      def solo
+      # An identifying attribute of the solo. Defaults to public_hostname.
+      def solo(identifier = EY::Metadata::DEFAULT_IDENTIFIER)
         if x = environment['instances'].detect { |i| i['role'] == 'solo' }
-          x['public_hostname']
+          x[identifier]
         end
       end
       

--- a/lib/engineyard-metadata/insider.rb
+++ b/lib/engineyard-metadata/insider.rb
@@ -36,14 +36,14 @@ module EY
       DELEGATED_TO_CHEF_DNA = METHODS - instance_methods.map { |m| m.to_s } - DELEGATED_TO_AMAZON_EC2_API
 
       DELEGATED_TO_AMAZON_EC2_API.each do |name|
-        define_method name do
-          amazon_ec2_api.send name
+        define_method name do |*args|
+          amazon_ec2_api.send name, *args
         end
       end
 
       DELEGATED_TO_CHEF_DNA.each do |name|
-        define_method name do
-          chef_dna.send name
+        define_method name do |*args|
+          chef_dna.send name, *args
         end
       end
     end

--- a/lib/engineyard-metadata/metadata.rb
+++ b/lib/engineyard-metadata/metadata.rb
@@ -16,6 +16,9 @@ module EY
     class CannotGetFromHere < RuntimeError
     end
 
+    # The default instance identifier for selector methods
+    DEFAULT_IDENTIFIER = 'public_hostname'
+
     attr_writer :app_name
     
     METHODS = %w{

--- a/lib/engineyard-metadata/outsider.rb
+++ b/lib/engineyard-metadata/outsider.rb
@@ -80,8 +80,8 @@ module EY
       end
   
       GETTABLE.each do |name|
-        define_method name do
-          engine_yard_cloud_api.send name
+        define_method name do |*args|
+          engine_yard_cloud_api.send name, *args
         end
       end
     end

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -21,12 +21,25 @@ shared_examples_for "it does in all execution environments" do
     EY.metadata.app_servers.should == ["ec2-174-129-212-130.compute-1.amazonaws.com"]
   end
 
+  it 'by getting the app server IDs' do
+    EY.metadata.app_servers('amazon_id').should == ['i-ff17d493']
+  end
+
   it 'by getting the db server hostnames' do
     EY.metadata.db_servers.should == ["ec2-67-202-19-255.compute-1.amazonaws.com"]
   end
 
+  it 'by getting the db server instance IDs' do
+    EY.metadata.db_servers('amazon_id').should == ['i-f917d495']
+  end
+
+
   it 'by getting the utilities hostnames' do
     EY.metadata.utilities.should == []
+  end
+
+  it 'by getting the utilities IDs' do
+    EY.metadata.utilities('amazon_id').should == []
   end
 
   it 'by getting the app master hostname' do
@@ -37,12 +50,24 @@ shared_examples_for "it does in all execution environments" do
     EY.metadata.db_master.should == 'ec2-67-202-19-255.compute-1.amazonaws.com'
   end
 
+  it 'by getting the db master instance ID' do
+    EY.metadata.db_master('amazon_id').should == 'i-f917d495'
+  end
+
   it 'by getting the db slave hostnames' do
     EY.metadata.db_slaves.should == []
   end
 
+  it 'by getting the db slave instance IDs' do
+    EY.metadata.db_slaves('amazon_id').should == []
+  end
+
   it 'by getting the app slave hostnames' do
     EY.metadata.app_slaves.should == []
+  end
+
+  it 'by getting the app slave hostnames' do
+    EY.metadata.app_slaves('amazon_id').should == []
   end
 
   it 'by getting the solo hostname' do

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -216,6 +216,7 @@ describe 'EY.metadata' do
     end
     describe "depending on .eyrc" do
       before do
+        FileUtils.mkdir_p File.dirname(EY.metadata.eyrc_path)
         File.open(EY.metadata.eyrc_path, 'w') { |f| f.write({'api_token' => FAKE_CLOUD_TOKEN + 'ccc'}.to_yaml) }
         EY.metadata.environment_name = 'cm1_production_blue'
         EY.metadata.ey_cloud_token.should == FAKE_CLOUD_TOKEN + 'ccc' # sanity check

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ require 'rspec'
 require 'active_support/json/encoding'
 require 'fakeweb'
 require 'fakefs/safe'
-require 'eat' # otherwise it's loaded when fakefs is already active
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'engineyard-metadata'


### PR DESCRIPTION
This pull request contains two bug fixes and one feature suggestion.

First, I was unable to get the code as it exists to work on Ruby 1.8.7 or 1.9.3 without 508de4d or 5ca121c. 
- 508de4d simply corrects the assumption that a home directory exists in FakeFS. Without the home directory, you can't create the .eyrc file :-)
- 5ca121c was the result of failed eat (0.1.8) calls. They simply weren't getting intercepted by FakeWeb, so I replaced them with open-uri-based open() calls. I'm happy to have this patch replaced by a working version of eat.

Second, the reason I was doing this work at all...
- a6574ce allows the user to ask for attributes other than public_hostname. I need this because I am working on a project in which I will be automatically creating EC2 ELB instances inside an EY environment (!) and I didn't want to write a dna.json parser when a nice one like engineyard-metadata already existed. Note that I forced the attribute "amazon_id" to mean "amazon_id" in the case of EY API calls, and "id" in the case of dna.json parsing.
